### PR TITLE
hot fix to ensure gazebo plugins are there

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
     python3-pip \
     python3-rosdep \
     ros-humble-rviz2 \
+    ros-humble-gazebo-plugins \
     zenoh-bridge-ros2dds
 
 # get the source tree and analyse it for its package.xml only


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

explicitly installing `gazebo_plugins` as part of the DevContainer build. This shouldn't be needed once https://github.com/LCAS/limo_ros2/pull/25 is properly merged, but it doesn't harm for now either.

## Related Tickets & Documents

- Related PR https://github.com/LCAS/limo_ros2/pull/25

## QA Instructions, Screenshots, Recordings

Please test the devcontainer
