### PR TITLE
switch to pre-build image

### DIFF
--- a/.devcontainer/cuda-opengl/devcontainer.json
+++ b/.devcontainer/cuda-opengl/devcontainer.json
@@ -1,17 +1,15 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
-	"name": "L-CAS Humble CUDA-OpenGL Devcontainer",
-	// Use the below image to not build locally (pushed by GitHub Action)
-	// disable the "build" section below in this case
-	// "image": "lcas.lincoln.ac.uk/devcontainer/lcas/rob2002:cuda-opengl-main",
-	"build": {
-		"dockerfile": "../Dockerfile",
-		"args": {
-			"BASE_IMAGE": "lcas.lincoln.ac.uk/lcas/ros:jammy-humble-cuda12.2-opengl"
-		},
-		"context": "../.."
-	},
+	"name": "L-CAS Humble CUDA-OpenGL ROB2002 Devcontainer",
+	"image": "lcas.lincoln.ac.uk/devcontainer/lcas/rob2002:cuda-opengl-deployment",
+	//"build": {
+	//	"dockerfile": "../Dockerfile",
+	//	"args": {
+	//		"BASE_IMAGE": "lcas.lincoln.ac.uk/lcas/ros:jammy-humble-cuda12.2-opengl"
+	//	},
+	//	"context": "../.."
+	//},
 
 	"forwardPorts": [5801],
 	"portsAttributes": {

--- a/.github/workflows/dev-container.yml
+++ b/.github/workflows/dev-container.yml
@@ -1,6 +1,5 @@
 name: 'devcontainer CI' 
 on:
-  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -12,19 +11,12 @@ on:
     
 jobs:
   build_devcontainer:
-    # only run for LCAS repositories
-    if: github.repository_owner == 'LCAS' || github.repository_owner == 'lcas'
-    runs-on: lcas
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         config: 
           - cuda-opengl
     steps:
-      - name: Node Js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "^16.13.0 || >=18.0.0"
-
       - name: Checkout from github
         uses: actions/checkout@v3
       - name: extract the github reference
@@ -32,36 +24,11 @@ jobs:
       - name: "image name from repo name"
         id: docker_image_name
         run: echo "docker_image=${{ github.repository }}" | tr '[:upper:]' '[:lower:]' |sed 's/[^0-9,a-z,A-Z,=,_,\/]/-/g' >>${GITHUB_OUTPUT}
-
-      - name: Docker Login LCAS
-        # don't attempt to login for PRs
-        if: ${{ github.event_name != 'pull_request' }} 
-        # You may pin to the exact commit or the version.
-        # uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        uses: docker/login-action@v2
-        with:
-          # Server address of Docker registry. If not set then will default to Docker Hub
-          registry: lcas.lincoln.ac.uk
-          # Username used to log against the Docker registry
-          username: ${{ secrets.LCAS_REGISTRY_PUSHER }}
-          # Password or personal access token used to log against the Docker registry
-          password: ${{ secrets.LCAS_REGISTRY_TOKEN }}
-  
       - name: Build dev container task
-        if: ${{ github.event_name == 'pull_request' }} 
         uses: devcontainers/ci@v0.3
         with:
           imageName: lcas.lincoln.ac.uk/devcontainer/${{ steps.docker_image_name.outputs.docker_image }}
           configFile: ./.devcontainer/${{ matrix.config }}/devcontainer.json
           push: never
-          imageTag: ${{ matrix.config }}-${{ env.BRANCH }}
-          #runCmd: "bash .devcontainer/run-ci.sh"
-      - name: Build and push dev container image
-        if: ${{ github.event_name != 'pull_request' }} 
-        uses: devcontainers/ci@v0.3
-        with:
-          imageName: lcas.lincoln.ac.uk/devcontainer/${{ steps.docker_image_name.outputs.docker_image }}
-          configFile: ./.devcontainer/${{ matrix.config }}/devcontainer.json
-          push: always
           imageTag: ${{ matrix.config }}-${{ env.BRANCH }}
           #runCmd: "bash .devcontainer/run-ci.sh"


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

This PR switch the devcontainer from building locally to using the docker image from the repository, build via the [`deployment` branch](https://github.com/LCAS/ROB2002/tree/deployment).

This will separate the building of the docker image from the students' use case.

